### PR TITLE
Minor typo in DESCRIPTION prevents loading.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: testr
 Title: Tools for Bayesian analysis of A/B tests
 Version: 0.1
-Authors@R: "Alex Yakubovich <alex.yakubovich@uken.com>"
+Authors: "Alex Yakubovich <alex.yakubovich@uken.com>"
 Description: testr is a set of tools for Bayesian analysis of randomized experiments (A/B tests).It uses an adaptive design (i.e. early stopping rules), allowing tests to end as early as possible. Currently supports probability models for binary data (e.g. retention, conversion metrics) as well as zero-inflated data (e.g. Lifetime value).  
 Depends: R (>= 3.1.1)
 License: MIT


### PR DESCRIPTION
Simple typo fix of the `authors` field.
